### PR TITLE
Remove the About layout control, plus webhook docs

### DIFF
--- a/docs/sanity-cms.md
+++ b/docs/sanity-cms.md
@@ -130,6 +130,37 @@ Test it by editing the About page and hitting Publish. A run should appear in th
 repo's Actions tab within a few seconds, and the site updates in a couple of
 minutes.
 
+### Debugging the webhook
+
+Delivery attempts are visible from the CLI, which is faster than the web UI:
+
+```bash
+cd studio
+npx sanity hooks list                     # confirm it exists
+npx sanity hooks logs "Deploy Website"    # status code of each attempt
+```
+
+`204` is success — that's what GitHub returns for an accepted dispatch. What the
+failures mean:
+
+| Code | Cause |
+| --- | --- |
+| `401` | GitHub didn't get valid credentials. Check the token is in an **Authorization header** with a `Bearer ` prefix — not in Sanity's "Secret" field, which is for HMAC signing and which GitHub ignores. Also suspect a truncated paste, or an expired token. |
+| `403` | Token is valid but lacks the `repo` scope. |
+| `404` | Wrong repository in the URL, or the token can't see it. |
+| `422` | GitHub got the request but no `event_type` — the Projection field is missing or wrong. |
+
+Two things that surprise people:
+
+- **Editing the webhook config doesn't re-fire it.** It only fires when a
+  document changes, so you need to publish a real edit to retest. Sanity leaves
+  Publish disabled when nothing has actually changed.
+- **A deploy triggered this way shows up in Actions with the event
+  `repository_dispatch`** and the title `sanity-publish`, not as a push. That's
+  how you tell a content deploy from a code deploy at a glance.
+
+Expect roughly a minute from Publish to live.
+
 ## Testing locally
 
 Two servers, two terminal tabs. They're independent — the Studio talks straight

--- a/studio/sanity.cli.ts
+++ b/studio/sanity.cli.ts
@@ -7,6 +7,10 @@ export default defineCliConfig({
   // Where `npx sanity deploy` publishes the Studio: <studioHost>.sanity.studio
   studioHost,
   // The Studio is deployed on its own, never as part of the Astro site build.
-  // Auto-updates let Sanity ship Studio patches without a redeploy from here.
-  deployment: { autoUpdates: true },
+  deployment: {
+    // Auto-updates let Sanity ship Studio patches without a redeploy from here.
+    autoUpdates: true,
+    // Identifies the deployed Studio app, so `sanity deploy` doesn't prompt.
+    appId: "djlbchqfa077dxz00wisg42g",
+  },
 });


### PR DESCRIPTION
Two changes, plus a fix for something that was already broken.

## 1. The About page no longer lets editors choose layout

The schema had a per-section **Appearance** picker (centred vs boxed). That's a layout control, and the agreed principle is that editors change text and reorder items — they don't choose presentation.

Sections now alternate plain / boxed / plain by position, which reproduces the current page exactly. Reordering sections changes which ones are boxed; that's the intended trade-off for removing the choice.

Includes `studio/scripts/unset-about-style.mjs` to clear the leftover stored values. One gotcha recorded there: a bare `sections[].style` wildcard **does not match** on unset — array members must be addressed by `_key`.

### This broke the build, on purpose

Unsetting those values before this code was deployed failed the build, because the old schema still required the field:

```
[InvalidContentEntryDataError] about → about data does not match collection schema.
  sections.0.style: Expected `"'centered' | 'card'"`, received `"null"`
```

Working as designed — Zod caught the mismatch and `deploy-pages` never ran, so the live site kept serving the previous build rather than shipping something broken. Worth remembering that schema, template, and stored content have to move together.

## 2. Webhook debugging notes

`docs/sanity-cms.md` now records what the failure codes mean and the two things that surprise people:

- Putting the GitHub token in Sanity's **Secret** field returns `401`. That field is for HMAC signing; GitHub ignores it. The token has to be an `Authorization` header with a `Bearer ` prefix.
- **Editing the webhook config doesn't re-fire it.** Only a document change does, so a correct fix looks broken until you publish a real edit.

Also pins `appId` in `studio/sanity.cli.ts` so `sanity deploy` stops prompting.

## 3. Fixes a pre-existing type error

`npm run type-check` has been failing since the project ID landed in #15 — with a real ID committed, TypeScript correctly flags the placeholder comparison as impossible. Nothing caught it because **CI doesn't run type-check or lint**. Worth adding as a PR check separately.

## Verified

- `astro check`: 0 errors
- Lint clean on all touched files
- The `style` unset confirmed against the uncached API, with `pageTitle` and all three headings preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)