### PR TITLE
Fix birth year ranges: they belong to the age group, not the team

### DIFF
--- a/studio/schemaTypes/team.ts
+++ b/studio/schemaTypes/team.ts
@@ -120,7 +120,7 @@ export const team = defineType({
       type: "string",
       group: "details",
       description:
-        'Eligibility window for this age group, shown on the Tryouts page, e.g. "SEPT 2014 - DEC 2015". Shifts by a year each season.',
+        'Eligibility window for this age group, shown on the Tryouts page, e.g. "SEPT 2013 - DEC 2014". Fixed per age group — it does not change from season to season. When a team moves up an age group, use the window for its new group.',
     }),
     defineField({
       name: "tryoutPhone",

--- a/studio/scripts/add-tryout-details.mjs
+++ b/studio/scripts/add-tryout-details.mjs
@@ -4,12 +4,16 @@
  * Phone numbers come from the previous hardcoded tryouts page (they were
  * identical in both the old and current versions of that file).
  *
- * Birth year ranges are shifted forward one season from the last generic
- * tryouts page, which covered 2026:
- *   2026: 10U = SEPT 2014 - DEC 2015, 12U = SEPT 2012 - DEC 2013, 13U = SEPT 2011 - DEC 2012
- *   2027: 11U = SEPT 2014 - DEC 2015, 13U = SEPT 2012 - DEC 2013, 14U = SEPT 2011 - DEC 2012
- * A player born SEPT 2014 - DEC 2015 was 10U in 2026 and is 11U in 2027, so the
- * ranges carry over intact — but these are worth a human check.
+ * Birth year ranges belong to the age group, not to the team, and do NOT shift
+ * from season to season. 11U is always the same window; it's the teams that move
+ * between age groups. So each team takes the range for whichever age group it now
+ * plays in, read straight off the previous tryouts page:
+ *
+ *   10U = SEPT 2014 - DEC 2015
+ *   11U = SEPT 2013 - DEC 2014
+ *   12U = SEPT 2012 - DEC 2013
+ *   13U = SEPT 2011 - DEC 2012
+ *   14U = SEPT 2010 - DEC 2011
  *
  * Run from the studio/ folder:
  *   npx sanity exec scripts/add-tryout-details.mjs --with-user-token
@@ -19,17 +23,20 @@ import { getCliClient } from "sanity/cli";
 const client = getCliClient();
 
 const DETAILS = {
+  // 11U Brown
   "team-brown": {
     tryoutPhone: "(614) 989-6569",
-    birthYears: "SEPT 2014 - DEC 2015",
+    birthYears: "SEPT 2013 - DEC 2014",
   },
+  // 13U Allen
   "team-allen": {
     tryoutPhone: "(614) 917-8858",
-    birthYears: "SEPT 2012 - DEC 2013",
+    birthYears: "SEPT 2011 - DEC 2012",
   },
+  // 14U Jones
   "team-jones": {
     tryoutPhone: "(614) 440-8009",
-    birthYears: "SEPT 2011 - DEC 2012",
+    birthYears: "SEPT 2010 - DEC 2011",
   },
 };
 


### PR DESCRIPTION
I had shifted each team's eligibility window forward as it aged up, assuming the range travelled with the cohort. It doesn't — the window belongs to the age group and stays put. Teams move between groups; the groups don't move.

| Team | Was (wrong) | Now |
| --- | --- | --- |
| 11U Brown | SEPT 2014 - DEC 2015 | **SEPT 2013 - DEC 2014** |
| 13U Allen | SEPT 2012 - DEC 2013 | **SEPT 2011 - DEC 2012** |
| 14U Jones | SEPT 2011 - DEC 2012 | **SEPT 2010 - DEC 2011** |

Values read straight off the age-group table on the previous tryouts page.

**The stored data is already corrected and live** — verified on https://firecrackersohio.com/tryouts/. This PR fixes the code that set it.

The more important part is the **Studio field description**, which said the range *"shifts by a year each season"*. That was my wrong assumption written into the UI, where it would have misled whoever edits this next season. It now says the window is fixed per age group, and that a team moving up should take its new group's window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)