### PR TITLE
Deploy the Sanity Studio from CI

### DIFF
--- a/.github/workflows/studio.yml
+++ b/.github/workflows/studio.yml
@@ -1,0 +1,70 @@
+name: Deploy Sanity Studio
+
+# The Studio at firecrackersohio.sanity.studio is a separate bundle from the
+# website, so a schema change merged to `main` does nothing until it's deployed.
+# Before this workflow existed that was a manual `npm run deploy`, and forgetting
+# it left the Studio showing field labels and help text that no longer matched
+# the repo. See docs/sanity-cms.md.
+on:
+  push:
+    branches: [main]
+    # Nothing outside studio/ affects what the Studio serves. Content edits
+    # never need a redeploy at all — those go straight to the dataset.
+    paths:
+      - "studio/**"
+      - ".github/workflows/studio.yml"
+  # Lets you force a redeploy from the Actions tab without a code change.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A second push while a deploy is running should supersede it, not race it.
+concurrency:
+  group: studio-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: studio
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # Sanity 6 requires Node >= 22.12.
+          node-version: 22
+          cache: npm
+          cache-dependency-path: studio/package-lock.json
+
+      # Checked before the install so a missing token fails in seconds. This
+      # fails the run rather than skipping quietly: a silent skip would put the
+      # Studio right back to drifting from the schema, which is the problem
+      # this workflow exists to prevent.
+      - name: Check the deploy token is set
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+        run: |
+          if [ -z "$SANITY_AUTH_TOKEN" ]; then
+            echo "::error::SANITY_AUTH_TOKEN is not set. Add it under Settings → Secrets and variables → Actions. See docs/sanity-cms.md → 'Deploying the Studio'."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      # studioHost and appId are set in studio/sanity.cli.ts, so there is
+      # nothing to prompt for; --yes is belt and braces for a non-interactive
+      # shell.
+      - name: Deploy the Studio
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+        run: npx sanity deploy --yes
+
+      - name: Summarise
+        run: echo "Deployed https://firecrackersohio.sanity.studio" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Team photos and player headshots are Sanity assets served from its CDN via `src/
 
 The About page and all team content come from Sanity — see `docs/sanity-cms.md`.
 
-- `studio/` is a **separate npm package** (its own `package.json`, excluded from the root `tsconfig.json`) holding the Studio config and schema. Its deps are deliberately kept out of the website build. Deployed on its own with `npm run deploy` from `studio/`.
+- `studio/` is a **separate npm package** (its own `package.json`, excluded from the root `tsconfig.json`) holding the Studio config and schema. Its deps are deliberately kept out of the website build. It is a separate deploy from the website: `.github/workflows/studio.yml` runs `sanity deploy` on any push to `main` touching `studio/**`, and `npm run deploy` from `studio/` does it by hand. **Schema edits — including field titles and descriptions — do nothing on the hosted Studio until that runs.**
 - `src/lib/sanity/loader.ts` is a generic Astro content-collection loader — reuse it for new document types rather than fetching in page frontmatter.
 - Rich text (Portable Text) renders through `src/components/RichText.astro`; paragraph styling comes from `.rich-text` / `.rich-text-xl` in `global.css`.
 - A Sanity webhook triggers `repository_dispatch: sanity-publish` in `deploy.yml` on publish.

--- a/docs/sanity-cms.md
+++ b/docs/sanity-cms.md
@@ -82,6 +82,10 @@ npm run deploy
 Pick the hostname when prompted, or keep the `studioHost` already set in
 `studio/project.ts`. Result: `https://firecrackersohio.sanity.studio`.
 
+This is the only deploy you have to run by hand. After it, changes under `studio/`
+redeploy on merge — see [Deploying the Studio](#deploying-the-studio) for the one
+secret that needs.
+
 Then invite the coaches: **sanity.io/manage → Members → Invite**. The free plan
 includes a limited number of users, so check the count before inviting everyone.
 Give coaches the **Editor** role, not Administrator.
@@ -134,6 +138,41 @@ Three parts of that table matter more than they look:
   `repository_dispatch: types: [sanity-publish]` trigger in
   `.github/workflows/deploy.yml`. The `client_payload` part is what lets the
   notification email say which document changed.
+
+## Deploying the Studio
+
+The Studio is its own bundle, separate from the website. A schema change merged to
+`main` — a new field, or just reworded help text — does nothing at
+firecrackersohio.sanity.studio until that bundle is rebuilt. Content edits are
+different: they go straight to the dataset and never need a deploy.
+
+`.github/workflows/studio.yml` does the rebuild on any push to `main` that touches
+`studio/**`. It's deliberately a separate workflow from the website deploy —
+different trigger, and a failed Studio deploy shouldn't block the site going out.
+
+It needs one secret, `SANITY_AUTH_TOKEN`:
+
+1. **sanity.io/manage → API → Tokens → Add token.** Give it the **Deploy Studio**
+   role if the project offers it, otherwise **Administrator** — a Viewer or Editor
+   token can read and write content but can't deploy.
+2. Add it to the repo as `SANITY_AUTH_TOKEN` under **Settings → Secrets and
+   variables → Actions**.
+3. **Note its expiry date somewhere**, same as the webhook token below.
+
+If the secret is missing, the workflow fails on its first step and says so rather
+than skipping quietly. A skipped deploy is exactly the silent drift this is meant
+to stop.
+
+Deploying by hand still works, and is what you'll do for first-time setup before
+the secret exists:
+
+```bash
+cd studio
+npm run deploy
+```
+
+To force a redeploy without a code change, use **Actions → Deploy Sanity Studio →
+Run workflow**.
 
 ## Getting emailed when someone publishes
 
@@ -352,8 +391,11 @@ nulls recursively before validation (`stripNulls` in
 `useCdn: false`. Sanity's cached endpoint is eventually consistent, so a build
 starting seconds after Publish could otherwise pick up the previous version.
 
-**Changing the schema needs a redeploy.** Editing files in `studio/` (adding a
-field, say) requires `npm run deploy` from `studio/`. Content edits never do.
+**Changing the schema needs a redeploy.** Editing files in `studio/` — adding a
+field, or just reworking a field's help text — changes nothing at
+firecrackersohio.sanity.studio until the Studio bundle is rebuilt. Content edits
+never need this. `.github/workflows/studio.yml` handles it on merge; see
+[Deploying the Studio](#deploying-the-studio).
 
 ### Private datasets
 


### PR DESCRIPTION
## Why

The Studio at firecrackersohio.sanity.studio is a separate bundle from the website. A schema change merged to `main` did nothing there until someone ran `npm run deploy` from `studio/` by hand — and nothing indicated the two had diverged. That's how the `birthYears` description ended up showing the old text in the Studio while `main` had the new one.

## What

- **`.github/workflows/studio.yml`** — runs `sanity deploy` on any push to `main` touching `studio/**`, plus `workflow_dispatch` for a forced redeploy. Separate from the Pages workflow on purpose: different trigger, and a failed Studio deploy shouldn't hold up the site.
- Node 22 (Sanity 6 requires >= 22.12), `npm ci` against `studio/package-lock.json`, `npx sanity deploy --yes`. `studioHost` and `appId` are already in `studio/sanity.cli.ts`, so there is nothing to prompt for.
- `SANITY_AUTH_TOKEN` is checked as the **first** step and the run **fails** if it's missing, rather than skipping the way the mail steps do. A quiet skip is how the Studio drifted in the first place.
- `concurrency` so a second push supersedes an in-flight deploy.
- Docs: new "Deploying the Studio" section covering the token; the gotcha in `docs/sanity-cms.md` points at it. `CLAUDE.md` notes that schema edits — descriptions included — are inert until the Studio deploys.

## Verification

- `npx sanity deploy --dry-run --yes` in `studio/` builds and would upload, confirming the flags and config need no prompts.
- Prettier passes on all three files.
- The `SANITY_AUTH_TOKEN` secret is set.
- Merging this exercises the workflow immediately, since the path filter includes the workflow file itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)