### PR TITLE
Install the website's deps before building the Studio

### DIFF
--- a/.github/workflows/studio.yml
+++ b/.github/workflows/studio.yml
@@ -32,15 +32,18 @@ jobs:
         working-directory: studio
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # Sanity 6 requires Node >= 22.12.
           node-version: 22
           cache: npm
-          cache-dependency-path: studio/package-lock.json
+          # Both lockfiles, because both installs happen below.
+          cache-dependency-path: |
+            package-lock.json
+            studio/package-lock.json
 
       # Checked before the install so a missing token fails in seconds. This
       # fails the run rather than skipping quietly: a silent skip would put the
@@ -55,7 +58,18 @@ jobs:
             exit 1
           fi
 
-      - name: Install dependencies
+      # The website's dependencies, which the Studio build needs despite the two
+      # packages being separate. The Studio's bundler reads the nearest
+      # tsconfig.json it can find for the generated entry at
+      # studio/.sanity/runtime/app.js, walks up to the repo root one, and fails
+      # on its `extends: astro/tsconfigs/strict` if root node_modules is absent —
+      # "Tsconfig not found astro/tsconfigs/strict". Nobody hits this locally
+      # because a checkout you develop in has both installed.
+      - name: Install the website's dependencies
+        working-directory: .
+        run: npm ci
+
+      - name: Install the Studio's dependencies
         run: npm ci
 
       # studioHost and appId are set in studio/sanity.cli.ts, so there is


### PR DESCRIPTION
Second follow-up to #19. The Studio deploy got past `npm ci` after #20, then failed in `sanity deploy`:

```
[rolldown:vite-resolve] plugin `rolldown:vite-resolve` threw an error
Caused by:
    Tsconfig not found astro/tsconfigs/strict
```

## Cause

`sanity build` generates its entry at `studio/.sanity/runtime/app.js`. `studio/tsconfig.json` includes only `./**/*.ts` and `./**/*.tsx`, so it doesn't match a `.js` file; the bundler walks up to the repo-root `tsconfig.json` and tries to follow its `extends: "astro/tsconfigs/strict"`, which lives in root `node_modules`. The workflow only installed `studio/`, so it wasn't there.

This is invisible locally: any checkout you actually develop in has both installed.

## Fix

`npm ci` at the repo root before the Studio install. Boring, and independent of how the bundler picks a tsconfig — broadening `studio/tsconfig.json`'s `include` to cover `.js` was tried first and did **not** help, so the matching rule isn't what it appears to be and isn't worth depending on.

Also bumps `actions/checkout` and `actions/setup-node` to v7, clearing the Node 20 deprecation warning that annotated every run.

## Verification

Reproduced in a clean clone of `main` with only `studio/` installed — `npx sanity build` fails exactly as CI did. Adding a root `npm ci` (6.6s, warm cache) makes it succeed. The root lockfile is in sync, incidentally: `npm ci` at the root passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)