### PR TITLE
Check pull requests, and fail the build on empty content

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,94 @@
+name: Checks
+
+# The website deploy and the Studio deploy both only run after a merge, so
+# without this workflow a pull request got no automated validation at all and
+# merging was the first time anything ran. Two real breakages reached `main`
+# that way: a stale studio/package-lock.json and a Studio build that couldn't
+# resolve the root tsconfig.
+on:
+  pull_request:
+  # Also on main, so a direct push doesn't skip the checks either.
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Superseded pushes to the same branch don't need finishing.
+concurrency:
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  website:
+    name: Website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Cheapest first, so an obvious formatting miss fails in seconds rather
+      # than after a full build.
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type-check
+        run: npm run type-check
+
+      # Also the only check that the site's Sanity content still satisfies the
+      # collection schemas, since the build is what fetches it.
+      - name: Build
+        run: npm run build
+
+  studio:
+    name: Studio
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: studio
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          # Sanity 6 requires Node >= 22.12.
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            studio/package-lock.json
+
+      # Needed for the Studio build, not for the website: see the comment in
+      # studio.yml. Running it here is what catches that class of failure before
+      # a merge rather than after.
+      - name: Install the website's dependencies
+        working-directory: .
+        run: npm ci
+
+      - name: Install the Studio's dependencies
+        run: npm ci
+
+      # The root tsconfig excludes studio/, so `npm run type-check` at the root
+      # never sees any of this.
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      # A dry run of what studio.yml does on merge, minus the upload. Needs no
+      # Sanity credentials, so it works on pull requests from forks too.
+      - name: Build
+        run: npx sanity build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ The About page and all team content come from Sanity — see `docs/sanity-cms.md
 - The project ID is duplicated in `src/lib/sanity/client.ts` and `studio/project.ts`; change both. It is not a secret.
 - **Document IDs must not contain a dot.** Sanity treats dotted prefixes as reserved namespaces and blocks unauthenticated reads, which silently empties the collection at build time. Use `team-jones`, never `team.jones`.
 - GROQ projections return `null` for unset fields; `stripNulls` in the loader removes them so Zod schemas can use plain `.optional()`.
+- The loader's `minEntries` option fails the build when a collection comes back empty, which Zod treats as valid. Both collections set it to `1`; set it on any new collection the site can't render without.
 - Editors get text, images and list ordering — never style or layout. New fields should follow that.
 
 ### Adding a New Team

--- a/docs/sanity-cms.md
+++ b/docs/sanity-cms.md
@@ -382,6 +382,11 @@ build reads without a token, that would have deployed a site with no teams at
 all, and no error, because an empty collection is valid. IDs are `team-jones`
 with a hyphen for this reason.
 
+That last part no longer holds, deliberately: the loader takes a `minEntries`
+option and both collections set it to 1, so a collection that comes back empty
+fails the build instead of quietly publishing a site without it. Set it on any
+new collection the site can't sensibly render without.
+
 **A GROQ projection returns null, not nothing.** Ask for a field that isn't set
 and you get `"email": null`, which Zod's `.optional()` rejects. The loader strips
 nulls recursively before validation (`stripNulls` in

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -31,6 +31,7 @@ const about = defineCollection({
       sections[]{ heading, body }
     }`,
     entryId: () => "about",
+    minEntries: 1,
   }),
   schema: z.object({
     pageTitle: z.string(),
@@ -74,6 +75,10 @@ const teams = defineCollection({
       results[]{ date, tournament, location, result }
     }`,
     entryId: doc => String(doc.slug),
+    // The nav, the Teams page and the Tryouts page are all derived from this
+    // collection, so an empty result would build a site with no teams at all
+    // and no error to show for it.
+    minEntries: 1,
   }),
   schema: z.object({
     name: z.string(),

--- a/src/lib/sanity/loader.ts
+++ b/src/lib/sanity/loader.ts
@@ -40,6 +40,18 @@ interface SanityLoaderOptions {
    * as "about" is nicer than Sanity's internal one.
    */
   entryId?: (_doc: SanityDocument, _index: number) => string;
+  /**
+   * Fails the build if the query returns fewer documents than this.
+   *
+   * Zod validates each document, but an empty result set is valid to Zod and to
+   * every page that maps over it — the site just builds without that content.
+   * For teams that means a Teams page with no teams, a nav with no menu and a
+   * Tryouts page with nothing to try out for, all from a green build. That has
+   * come close to shipping before: document IDs containing a dot are silently
+   * unreadable to the public API, which empties the collection rather than
+   * erroring. Set this on any collection the site can't sensibly render without.
+   */
+  minEntries?: number;
 }
 
 /**
@@ -57,7 +69,7 @@ interface SanityLoaderOptions {
 export function sanityLoader(options: SanityLoaderOptions): Loader {
   return {
     name: "sanity-loader",
-    load: async ({ store, parseData, generateDigest, logger }) => {
+    load: async ({ collection, store, parseData, generateDigest, logger }) => {
       const documents = await getSanityClient().fetch<SanityDocument[]>(
         options.query,
         options.params ?? {}
@@ -67,6 +79,19 @@ export function sanityLoader(options: SanityLoaderOptions): Loader {
         throw new Error(
           `[sanity-loader] Expected the GROQ query to return an array but got ${typeof documents}. ` +
             `Check the query: ${options.query}`
+        );
+      }
+
+      const minEntries = options.minEntries ?? 0;
+      if (documents.length < minEntries) {
+        throw new Error(
+          `[sanity-loader] The "${collection}" collection needs at least ${minEntries} ` +
+            `document(s) but Sanity returned ${documents.length}. The site would build ` +
+            `without this content rather than fail, so the build is stopped here.\n\n` +
+            `Likely causes: nothing published yet, a document ID containing a dot ` +
+            `(unreadable to the public API — see docs/sanity-cms.md), or a dataset or ` +
+            `project ID mismatch in src/lib/sanity/client.ts.\n\n` +
+            `Query: ${options.query}`
         );
       }
 


### PR DESCRIPTION
The first two items from the CI/CD review. Both address ways breakage reached `main` without anything going red.

## 1. Pull requests now get checked

The website deploy and the Studio deploy both fire only *after* a merge, so merging was the first time anything ran. That's how both of today's failures landed: a stale `studio/package-lock.json` (#20) and a Studio build that couldn't resolve the root tsconfig (#21). `checks.yml` runs on `pull_request` and on pushes to `main`:

- **Website** — `format:check`, `lint`, `type-check`, `build`. Cheapest first. The build doubles as the only check that Sanity content still satisfies the collection schemas.
- **Studio** — `npx tsc --noEmit` and `npx sanity build`. Both are new coverage: `studio/` is excluded from the root tsconfig and has never been type-checked anywhere, and nothing built it outside a deploy.

`sanity build` needs no credentials (verified with an empty `HOME` and no token), so the Studio job works on fork pull requests too.

## 2. An empty collection now fails the build

Zod validates each document but says nothing about there being *none*, and every page maps over the list happily. So a Sanity misconfiguration builds a site with no teams — no nav menu, no Teams listing, nothing on Tryouts — and deploys it with a green pipeline.

That isn't hypothetical: `docs/sanity-cms.md` records it nearly shipping, when dotted document IDs made every team unreadable to the public API and the collection came back empty.

The loader takes a `minEntries` option; both collections set it to `1`. The error names the likely causes rather than just the count:

```
[sanity-loader] The "teams" collection needs at least 1 document(s) but Sanity returned 0.
The site would build without this content rather than fail, so the build is stopped here.

Likely causes: nothing published yet, a document ID containing a dot (unreadable to the
public API — see docs/sanity-cms.md), or a dataset or project ID mismatch in
src/lib/sanity/client.ts.
```

## Verification

- Guard fires: pointed the teams query at a nonexistent type; build stopped with that message and exited 1. Restored, and a normal build passes with all 8 pages.
- `format:check`, `lint`, `type-check`, `build` pass at the root; `tsc --noEmit` and `sanity build` pass in `studio/`.
- This PR triggers `checks.yml` itself, so its own run is the proof it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)