### PR TITLE
Hide admin-only fields from coaches in the Studio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ The About page and all team content come from Sanity — see `docs/sanity-cms.md
 - GROQ projections return `null` for unset fields; `stripNulls` in the loader removes them so Zod schemas can use plain `.optional()`.
 - The loader's `minEntries` option fails the build when a collection comes back empty, which Zod treats as valid. Both collections set it to `1`; set it on any new collection the site can't render without.
 - Editors get text, images and list ordering — never style or layout. New fields should follow that.
+- Coaches are Sanity **Editors**; the site owner is an Administrator. `studio/roles.ts` exports `isAdmin()` and an `adminOnly` `hidden` callback — a handful of team fields, the About page and all create/delete actions are admin-only. It's UI clarity, not enforcement (per-field permissions are Enterprise-only). Never put `adminOnly` on a required field an Editor could leave empty: hidden + required + empty silently blocks publishing. See `docs/sanity-cms.md`.
 
 ### Adding a New Team
 

--- a/docs/sanity-cms.md
+++ b/docs/sanity-cms.md
@@ -88,7 +88,9 @@ secret that needs.
 
 Then invite the coaches: **sanity.io/manage → Members → Invite**. The free plan
 includes a limited number of users, so check the count before inviting everyone.
-Give coaches the **Editor** role, not Administrator.
+Give coaches the **Editor** role, not Administrator — Editors can publish on
+their own, and the Studio hides the admin-only fields from them. See
+[Who can edit what](#who-can-edit-what).
 
 At this point you can verify the site builds against real content:
 
@@ -314,6 +316,43 @@ The pieces worth reusing:
 Two things to remember for any new type: add it to the **webhook filter**, or
 publishing won't deploy, and give it a **hyphenated ID** (see the dot gotcha
 below).
+
+## Who can edit what
+
+Two kinds of user: **Administrator** (you) and **Editor** (the coaches). Coaches
+can publish without approval; they just see a shorter form.
+
+Hidden from Editors:
+
+| Hidden                                  | Where             | Why                                                                       |
+| --------------------------------------- | ----------------- | ------------------------------------------------------------------------- |
+| Team name                               | `team.name`       | Drives the nav, the age-group phrasing on Tryouts, and the document title |
+| Web address                             | `team.slug`       | Locked after creation; changing it breaks every link                      |
+| Birth year range                        | `team.birthYears` | An org-wide rule for the age group, not a per-team setting                |
+| About page                              | sidebar item      | Not a coach's page                                                        |
+| Create / delete / duplicate / unpublish | document actions  | Adding and removing teams is an admin job                                 |
+
+Everything else on a team — roster, coaching staff, schedule, results, headings,
+short description, team photo, social links, contact phone — is coach-editable.
+
+How it works: `studio/roles.ts` exports `isAdmin()` and an `adminOnly` callback,
+used as `hidden: adminOnly` on a field and as a conditional in the sidebar and
+document actions in `studio/sanity.config.ts`. To move a field between the two
+categories, add or remove that one line — and remember schema changes need a
+[Studio deploy](#deploying-the-studio) to reach the hosted Studio.
+
+Two things to know:
+
+- **It's for clarity, not security.** These are UI rules. Sanity enforces
+  per-field permissions only through custom roles, which are Enterprise-only, so
+  an Editor with an API token could still write a hidden field. `visionTool()` is
+  also enabled for everyone, so nothing in the dataset is actually concealed. The
+  goal is a short, obvious form.
+- **Never put `adminOnly` on a required field a coach can create empty.** Hidden
+  plus required plus empty blocks publishing with a validation error the coach
+  can't see the cause of. That's exactly why Editors can't create teams: you
+  create the team and set its name and web address, then the coach fills in the
+  rest.
 
 ## What editors deliberately cannot do
 

--- a/studio/roles.ts
+++ b/studio/roles.ts
@@ -1,0 +1,42 @@
+import {
+  userHasRole,
+  type ConditionalPropertyCallbackContext,
+  type CurrentUser,
+} from "sanity";
+
+/**
+ * The logged-in user as the Studio hands it to us. Field-level callbacks get a
+ * `CurrentUser` without the deprecated `role` singular, so accept the wider
+ * shape and every call site lines up.
+ */
+type StudioUser = Omit<CurrentUser, "role"> | null;
+
+/**
+ * Who sees what in the Studio.
+ *
+ * Coaches get Sanity's built-in **Editor** role, which can publish. Anything a
+ * coach shouldn't have to think about — the team name, the web address, the
+ * age-group birth years, the whole About page — is hidden from them here so the
+ * Studio only shows the fields they actually maintain.
+ *
+ * This is a clarity measure, not a security boundary. Per-field and per-document
+ * permissions come from Sanity's custom roles, which are an Enterprise feature;
+ * the Content Lake still accepts writes to these fields from anyone with edit
+ * access. That's fine for what this is: the point is a short, obvious form, not
+ * a lock.
+ */
+export function isAdmin(currentUser: StudioUser): boolean {
+  return userHasRole(currentUser, "administrator");
+}
+
+/**
+ * Drop-in `hidden` callback for fields only an administrator should see.
+ *
+ * Only use it on optional fields, or on required fields that are always filled
+ * in at creation time (`name`, `slug`). A required field that is both empty and
+ * hidden blocks publishing with an error the coach can't see the cause of —
+ * which is why coaches can't create teams; see `sanity.config.ts`.
+ */
+export const adminOnly = ({
+  currentUser,
+}: ConditionalPropertyCallbackContext) => !isAdmin(currentUser);

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -4,6 +4,7 @@ import { visionTool } from "@sanity/vision";
 
 import { schemaTypes, singletonTypes } from "./schemaTypes";
 import { dataset, projectId } from "./project";
+import { isAdmin } from "./roles";
 
 export default defineConfig({
   name: "default",
@@ -15,7 +16,9 @@ export default defineConfig({
     structureTool({
       // Custom sidebar. Because the About page is a singleton we link straight
       // to the one document instead of showing a list with a "create" button.
-      structure: S =>
+      // Coaches see only Teams — the About page isn't theirs to edit, so it
+      // isn't in their sidebar at all.
+      structure: (S, { currentUser }) =>
         S.list()
           .title("Website content")
           .items([
@@ -27,16 +30,20 @@ export default defineConfig({
                   .title("Teams")
                   .defaultOrdering([{ field: "name", direction: "asc" }])
               ),
-            S.divider(),
-            S.listItem()
-              .title("About page")
-              .id("aboutPage")
-              .child(
-                S.document()
-                  .schemaType("aboutPage")
-                  .documentId("aboutPage")
-                  .title("About page")
-              ),
+            ...(isAdmin(currentUser)
+              ? [
+                  S.divider(),
+                  S.listItem()
+                    .title("About page")
+                    .id("aboutPage")
+                    .child(
+                      S.document()
+                        .schemaType("aboutPage")
+                        .documentId("aboutPage")
+                        .title("About page")
+                    ),
+                ]
+              : []),
           ]),
     }),
     // Lets you run GROQ queries against the dataset from inside the Studio.
@@ -53,14 +60,21 @@ export default defineConfig({
 
   document: {
     // Strip "duplicate", "delete" and "unpublish" from singletons so an editor
-    // can't accidentally remove the only About page document.
-    actions: (actions, { schemaType }) =>
-      singletonTypes.has(schemaType)
+    // can't accidentally remove the only About page document. Coaches get the
+    // same treatment on every type: edit and publish, nothing structural.
+    actions: (actions, { schemaType, currentUser }) =>
+      singletonTypes.has(schemaType) || !isAdmin(currentUser)
         ? actions.filter(action =>
             ["publish", "discardChanges", "restore"].includes(
               action.action ?? ""
             )
           )
         : actions,
+
+    // Adding a team is an admin job — a coach who created one couldn't fill in
+    // the (hidden) name and web address, so publishing would fail on validation
+    // errors they can't see. This removes the "create" buttons for them.
+    newDocumentOptions: (options, { currentUser }) =>
+      isAdmin(currentUser) ? options : [],
   },
 });

--- a/studio/schemaTypes/team.ts
+++ b/studio/schemaTypes/team.ts
@@ -1,5 +1,7 @@
 import { defineArrayMember, defineField, defineType } from "sanity";
 
+import { adminOnly } from "../roles";
+
 /**
  * Rich text configuration shared by coach bios.
  *
@@ -64,6 +66,9 @@ export const team = defineType({
       group: "details",
       description:
         'Include the age group, e.g. "14U Jones" — update this when the team ages up. The website capitalises it for the big heading and adds "Team" where a longer name is needed, so this is the only place it needs changing.',
+      // Admin-only: the name drives the nav, the age-group phrasing on the
+      // Tryouts page and this document's title, so it's not a coach's call.
+      hidden: adminOnly,
       validation: Rule => Rule.required(),
     }),
     defineField({
@@ -74,8 +79,11 @@ export const team = defineType({
       description:
         '⚠️ Determines the page address, e.g. "jones" makes firecrackersohio.com/teams/jones. Locked once saved, because changing it would break every existing link to this team. Ask a developer if it genuinely needs changing.',
       options: { source: "name", maxLength: 40 },
-      // Settable when the team is first created, then locked.
+      // Settable when the team is first created, then locked — and never shown
+      // to coaches at all, since they can't change it and seeing it only invites
+      // questions.
       readOnly: ({ value }) => Boolean(value),
+      hidden: adminOnly,
       validation: Rule => Rule.required(),
     }),
     defineField({
@@ -121,6 +129,9 @@ export const team = defineType({
       group: "details",
       description:
         'Eligibility window for this age group, shown on the Tryouts page, e.g. "SEPT 2013 - DEC 2014".',
+      // Admin-only: this is an organisation-wide rule for the age group, not
+      // something a single team sets.
+      hidden: adminOnly,
     }),
     defineField({
       name: "tryoutPhone",


### PR DESCRIPTION
Coaches are Sanity **Editors** and publish their own changes without approval. This gives them a shorter form: fields they don't maintain are hidden, so there's nothing to wonder about.

## What a coach sees

Sidebar: just **Teams**. Their team's Details tab is short description, team photo, Instagram, Facebook, contact phone — then Roster, Coaches, Schedule, Results as before. The document title still shows the team name, so they always know where they are.

## Hidden from Editors

| Hidden | Where | Why |
| --- | --- | --- |
| Team name | `team.name` | Drives the nav, the Tryouts age-group phrasing, and the document title |
| Web address | `team.slug` | Locked after creation; changing it breaks every link |
| Birth year range | `team.birthYears` | An org-wide rule for the age group, not per-team |
| About page | sidebar item | Not a coach's page |
| Create / duplicate / delete / unpublish | document actions | Adding and removing teams is an admin job |

`studio/roles.ts` exports `isAdmin()` and an `adminOnly` callback; moving a field between categories is a one-line change.

## Two things to know

**Coaches can't create teams anymore, by design.** Name and web address are required, so a coach who created a team couldn't publish it — validation would fail on fields they can't see. An admin creates the team and sets those two, then hands it over. This is the tradeoff for hiding rather than disabling, and it's written down in `docs/sanity-cms.md`.

**Nothing here is enforced server-side.** These are UI rules. Sanity enforces per-field permissions only through custom roles, which are Enterprise-only, and `visionTool()` is enabled for everyone — so an Editor with an API token could still write a hidden field. The goal is a short, obvious form, not a lock.

## Testing

`tsc --noEmit`, `npm run lint`, `npm run format:check` and `sanity build` all pass. The role branching itself needs a real Editor login to see, so worth a check with one coach's account after deploy.

**This needs a Studio deploy to take effect** — `studio.yml` handles it on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)