### PR TITLE
Stop @playform/compress from minifying CSS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Tailwind CSS 4 with a custom `@theme` in `src/styles/global.css` defining brand 
 
 Fonts: Poppins (default), Almarai, Orbitron (accent).
 
-**Leave `vite.build.cssMinify: "esbuild"` in `astro.config.mjs` alone.** Setting it to `true` selects Lightning CSS under Vite 8, which rewrites `@media (min-width: …)` to range syntax that `@playform/compress` then silently deletes — the build stays green and every responsive style disappears. The config has the full explanation.
+**Two CSS settings in `astro.config.mjs` are load-bearing; leave both alone.** `vite.build.cssMinify` stays `"esbuild"` — `true` means Lightning CSS under Vite 8, which emits `@media (width >= …)` range syntax that iOS Safari below 16.4 can't parse, costing those browsers every responsive style. And `compress({ CSS: false })` keeps csso off the CSS, because it deletes range-syntax blocks outright. Either mistake produces a green build that looks broken only in a browser. The config explains both in full.
 
 ### Key Files
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,20 @@ import compress from "@playform/compress";
 // https://astro.build/config
 export default defineConfig({
   site: "https://firecrackersohio.com",
-  integrations: [sitemap(), compress()],
+  integrations: [
+    sitemap(),
+    // Compresses the built output in place: sharp over the images, svgo over the
+    // SVGs, html-minifier-terser over the HTML. That's worth about 2 MB on this
+    // site, most of it images, so it stays.
+    //
+    // CSS is deliberately excluded. Vite has already minified it by this point,
+    // and compress's CSS pass uses csso, which is old enough not to understand
+    // media query range syntax (`@media (width >= 48rem)`) — when it meets one
+    // it drops the whole block silently. That is how a build can pass every
+    // check and ship a site with no responsive styles; see the cssMinify note
+    // below. Skipping CSS here costs ~250 bytes and removes the trap.
+    compress({ CSS: false }),
+  ],
 
   // Pages for teams that no longer exist. On a static build Astro emits a small
   // HTML page with a meta refresh and a canonical link, since GitHub Pages can't
@@ -53,19 +66,19 @@ export default defineConfig({
 
     // Build optimizations
     build: {
-      // Must stay "esbuild" — do not change this to `true`.
+      // Kept as "esbuild" rather than `true`, which under Vite 8 means Lightning
+      // CSS. Lightning CSS rewrites `@media (min-width: 48rem)` into the modern
+      // range form `@media (width >= 48rem)`. That's valid CSS and 60 bytes
+      // smaller across the whole site, but iOS Safari below 16.4 doesn't parse
+      // it, and a browser that can't parse the media query loses every
+      // responsive style on the page. Not a trade worth making for 60 bytes on
+      // a site read on whatever phone a parent happens to own.
       //
-      // Vite 8 changed what `true` means: it now runs Lightning CSS, which
-      // rewrites `@media (min-width: 48rem)` into the equivalent modern range
-      // syntax `@media (width >= 48rem)`. The @playform/compress integration
-      // then minifies dist/ a second time with a parser that doesn't
-      // understand that syntax, and silently drops every one of those blocks.
-      //
-      // The result is a build that succeeds, type-checks and lints clean while
-      // shipping a site with no responsive styles at all — no `md:` or `lg:`
-      // utility survives, so the mobile menu shows on desktop and the desktop
-      // nav never appears. Pinning esbuild keeps the old output syntax, which
-      // compress handles, and produces byte-identical CSS to Astro 5.
+      // Getting this wrong is quiet: the build succeeds, type-check and lint
+      // pass, and the breakage is visible only in a browser. It is also how the
+      // Astro 7 upgrade nearly shipped a site with no responsive CSS at all —
+      // back then compress's csso pass deleted the range-syntax blocks outright
+      // rather than merely leaving old browsers behind.
       cssMinify: "esbuild",
       // There was a `rollupOptions.output.manualChunks` entry here splitting a
       // "vendor" chunk out of `astro`. It never produced one — the whole site


### PR DESCRIPTION
Follow-up to #34. Vite already minifies the CSS; compress then ran it through **csso** a second time. csso predates media query range syntax and deletes any block it can't parse — that's what nearly shipped a site with no responsive styles in the Astro 7 upgrade.

Right now nothing produces that syntax, so the trap is dormant, not fixed. One config change or a shift in Tailwind's output re-arms it. This takes csso off CSS entirely.

## Measured all four combinations first

| Variant | Total | CSS | Responsive CSS |
| --- | --- | --- | --- |
| Current (csso + esbuild) | 2,566,670 | 49,969 | ✅ |
| **This PR** (compress `CSS:false` + esbuild) | 2,566,922 | 50,221 | ✅ |
| compress `CSS:false` + lightningcss | 2,566,610 | 49,909 | ⚠️ range syntax |
| No compress at all | **4,645,559** | 49,909 | ⚠️ range syntax |

**Excluding CSS costs 252 bytes** — 0.01% of the output. csso was squeezing that much more out of esbuild's already-minified CSS; not worth keeping a silent-deletion hazard for.

**Dropping compress entirely was never viable.** It costs 2.08 MB, an 81% increase — its `sharp` pass is worth ~2 MB on the images alone. I'd originally estimated its value at "~92 KB", which was only the SVGs. It stays for images, SVG and HTML.

**The lightningcss variant is 60 bytes smaller than today and I rejected it.** It emits `@media (width >= 48rem)`, which iOS Safari below 16.4 can't parse — and a browser that can't parse the media query loses every responsive style on the page. Sixty bytes is not worth cutting off phones that haven't been updated since early 2023, on a site parents read on whatever handset they own.

## Also in here

Rewrote the `cssMinify` comment from #34. The reason to keep `"esbuild"` is now browser support rather than csso, so the old explanation was out of date the moment this PR landed. `CLAUDE.md` now flags both settings as load-bearing, since either mistake yields a green build that's broken only in a browser.

## Verification

- CSS: 50,221 bytes, all 13 `min-width` blocks present, zero range syntax
- Total output 2,566,922 — matches the measured variant exactly
- Images and SVG untouched (compress still handling both)
- type-check, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)