### PR TITLE
Stop ignoring eslint-plugin-astro majors in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,13 @@ updates:
           - "@eslint/*"
           - "eslint-plugin-*"
           - "typescript-eslint"
-    ignore:
-      # eslint-plugin-astro 2.x and 3.x require eslint-plugin-jsx-a11y >= 6.10.2
-      # as a peer, and 6.10.2 — still the newest release — declares support only
-      # up to eslint 9. So the chain cannot resolve, whichever way it's grouped.
-      # Drop this once jsx-a11y ships a release that accepts eslint 10.
-      - dependency-name: "eslint-plugin-astro"
-        update-types: ["version-update:semver-major"]
+    # Nothing ignored. There used to be a rule here holding eslint-plugin-astro
+    # back on 1.x, on the grounds that 2.x and 3.x can't resolve against eslint
+    # 10 because they need eslint-plugin-jsx-a11y >= 6.10.2 and 6.10.2 supports
+    # only up to eslint 9. Half right: that peer is declared *optional*, so the
+    # plugin installs and lints fine without it — only the plugin's jsx-a11y
+    # configs are unavailable, and we don't enable those. 3.1.0 went in by hand
+    # in #37, so the rule was suppressing updates for no reason.
 
   # The Studio's dependencies are deliberately separate from the website's, so
   # Dependabot has to be pointed at it explicitly.


### PR DESCRIPTION
Found while doing #37. `.github/dependabot.yml` had a rule holding `eslint-plugin-astro` on 1.x — which is why Dependabot never offered the upgrade and it had to be done by hand.

The stated reason:

> eslint-plugin-astro 2.x and 3.x require eslint-plugin-jsx-a11y >= 6.10.2 as a peer, and 6.10.2 — still the newest release — declares support only up to eslint 9. So the chain cannot resolve, whichever way it's grouped.

**Half right.** Every fact in it checks out, but the conclusion doesn't follow: that peer is declared **optional**. npm only tries to resolve it if you actually ask for `eslint-plugin-jsx-a11y`, which is why my first install attempt failed (I requested both) and installing the plugin alone succeeded. #37 has 3.1.0 running on ESLint 10 with lint passing on `.astro` files.

The only real casualty is the plugin's own `jsx-a11y` configs, which this repo doesn't enable — noted in `eslint.config.js`.

So the rule was suppressing updates for a problem that doesn't exist, and would have kept doing so for 4.x. Removed.

I kept the reasoning as a comment rather than deleting it. "We tried this and it doesn't work" is worth being able to check against later — particularly when it turns out to be wrong, so the next person doesn't re-derive the same wrong conclusion.

## Verification

YAML parses; all three ecosystems still have their groups, zero ignore rules remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)