### PR TITLE
Split the Schedule tab by season and let Results grow by year

### DIFF
--- a/docs/sanity-cms.md
+++ b/docs/sanity-cms.md
@@ -387,6 +387,16 @@ Things worth knowing:
   no photos shows the table instead. That's derived, not a setting.
 - **An empty roster is allowed** and shows "Coming soon". A team must always have
   at least one coach.
+- **The Schedule tab has two fixed tables**, fall and spring/summer, each with
+  its own heading and tournament list. Both are optional; whichever is empty
+  shows its heading above "Coming soon". The pair is fixed — a coach can't add a
+  third. (The fields are `fallSchedule` and, for historical reasons, plain
+  `schedule` for spring/summer.)
+- **The Results tab is a list of tables, one per year**, and coaches add them.
+  Each has a heading and its own finishes, and they render in the order they're
+  arranged in the Studio — newest year first by convention, not enforced. A new
+  season means adding a table, not overwriting the last one. A table with no rows
+  shows its heading above "Coming soon".
 - **Age groups live in the team name.** "14U Jones" is parsed to produce the
   "from 11U through 14U" phrasing on the home, teams and tryouts pages. Keep the
   `NNU` format or that phrase will silently drop that team.

--- a/src/components/teams/ResultsTable.astro
+++ b/src/components/teams/ResultsTable.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * One year's results on a team page: a heading and the finishes beneath it.
+ *
+ * The Results tab stacks as many of these as a coach has added, newest year
+ * first. Same shape as ScheduleTable with a Finish column on the end — kept as
+ * its own component rather than a shared configurable table, because that
+ * fourth column and its mobile handling are most of what a reader is here for.
+ */
+interface Props {
+  heading: string;
+  rows?: {
+    date: string;
+    tournament: string;
+    location: string;
+    result: string;
+  }[];
+}
+
+const { heading, rows } = Astro.props;
+---
+
+<h2 class="section-heading">{heading.toUpperCase()}</h2>
+{
+  rows && rows.length > 0 ? (
+    <div class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+      <table class="w-full text-left text-sm">
+        <thead>
+          <tr class="bg-red text-white">
+            <th class="px-4 py-3 font-semibold tracking-wide uppercase">
+              Date
+            </th>
+            <th class="px-4 py-3 font-semibold tracking-wide uppercase">
+              Tournament
+            </th>
+            <th class="hidden px-4 py-3 font-semibold tracking-wide uppercase sm:table-cell">
+              Location
+            </th>
+            <th class="px-4 py-3 font-semibold tracking-wide uppercase">
+              Result
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+          {rows.map((entry, i) => (
+            <tr
+              class={
+                i % 2 === 0
+                  ? "bg-white dark:bg-gray-900"
+                  : "bg-gray-50 dark:bg-gray-800/50"
+              }
+            >
+              <td class="px-4 py-3 font-mono text-xs whitespace-nowrap text-gray-600 dark:text-gray-400">
+                {entry.date}
+              </td>
+              <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                {entry.tournament}
+                <div class="mt-0.5 text-xs text-gray-500 sm:hidden dark:text-gray-400">
+                  {entry.location}
+                </div>
+              </td>
+              <td class="hidden px-4 py-3 text-gray-600 sm:table-cell dark:text-gray-400">
+                {entry.location}
+              </td>
+              <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                {entry.result}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : (
+    <div class="card">
+      <p class="body-text">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/components/teams/ScheduleTable.astro
+++ b/src/components/teams/ScheduleTable.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * One schedule table on a team page: a heading and the tournaments beneath it.
+ *
+ * The Schedule tab stacks two of these — fall, then spring/summer — so each
+ * carries its own heading and its own empty state. A season with nothing booked
+ * yet still shows its heading, with "Coming soon." underneath.
+ */
+interface Props {
+  heading: string;
+  rows?: { dates: string; tournament: string; location: string }[];
+}
+
+const { heading, rows } = Astro.props;
+---
+
+<h2 class="section-heading">{heading.toUpperCase()}</h2>
+{
+  rows && rows.length > 0 ? (
+    <div class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+      <table class="w-full text-left text-sm">
+        <thead>
+          <tr class="bg-red text-white">
+            <th class="px-4 py-3 font-semibold tracking-wide uppercase">
+              Dates
+            </th>
+            <th class="px-4 py-3 font-semibold tracking-wide uppercase">
+              Tournament
+            </th>
+            <th class="hidden px-4 py-3 font-semibold tracking-wide uppercase sm:table-cell">
+              Location
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+          {rows.map((event, i) => (
+            <tr
+              class={
+                i % 2 === 0
+                  ? "bg-white dark:bg-gray-900"
+                  : "bg-gray-50 dark:bg-gray-800/50"
+              }
+            >
+              <td class="px-4 py-3 font-mono text-xs whitespace-nowrap text-gray-600 dark:text-gray-400">
+                {event.dates}
+              </td>
+              <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                {event.tournament}
+                <div class="mt-0.5 text-xs text-gray-500 sm:hidden dark:text-gray-400">
+                  {event.location}
+                </div>
+              </td>
+              <td class="hidden px-4 py-3 text-gray-600 sm:table-cell dark:text-gray-400">
+                {event.location}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : (
+    <div class="card">
+      <p class="body-text">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -23,6 +23,21 @@ const sanityImage = z.looseObject({
 });
 
 /**
+ * Tournaments on a schedule. The fall and spring/summer tables hold the same
+ * shape, and either may be empty — a season nobody has booked yet renders its
+ * heading above "Coming soon" rather than disappearing.
+ */
+const scheduleEvents = z
+  .array(
+    z.object({
+      dates: z.string(),
+      tournament: z.string(),
+      location: z.string(),
+    })
+  )
+  .optional();
+
+/**
  * The About page, edited in Sanity Studio.
  *
  * A single document, so the collection holds exactly one entry, keyed "about".
@@ -70,12 +85,13 @@ const teams = defineCollection({
       teamPhoto,
       instagramUrl,
       facebookUrl,
+      fallScheduleHeading,
       scheduleHeading,
-      resultsHeading,
       staff[]{ name, role, email, bio },
       roster[]{ name, number, position, gradYear, highSchool, photo },
+      fallSchedule[]{ dates, tournament, location },
       schedule[]{ dates, tournament, location },
-      results[]{ date, tournament, location, result }
+      resultTables[]{ heading, rows[]{ date, tournament, location, result } }
     }`,
     entryId: doc => String(doc.slug),
     // The nav, the Teams page and the Tryouts page are all derived from this
@@ -94,8 +110,8 @@ const teams = defineCollection({
     // z.string().url().
     instagramUrl: z.url().optional(),
     facebookUrl: z.url().optional(),
+    fallScheduleHeading: z.string(),
     scheduleHeading: z.string(),
-    resultsHeading: z.string(),
     staff: z
       .array(
         z.object({
@@ -118,22 +134,25 @@ const teams = defineCollection({
         })
       )
       .optional(),
-    schedule: z
+    fallSchedule: scheduleEvents,
+    schedule: scheduleEvents,
+    // One table per year, newest first, in whatever order the coach arranged
+    // them. A table with no rows is legitimate — a season underway with nothing
+    // to report yet — and renders its heading above "Coming soon".
+    resultTables: z
       .array(
         z.object({
-          dates: z.string(),
-          tournament: z.string(),
-          location: z.string(),
-        })
-      )
-      .optional(),
-    results: z
-      .array(
-        z.object({
-          date: z.string(),
-          tournament: z.string(),
-          location: z.string(),
-          result: z.string(),
+          heading: z.string(),
+          rows: z
+            .array(
+              z.object({
+                date: z.string(),
+                tournament: z.string(),
+                location: z.string(),
+                result: z.string(),
+              })
+            )
+            .optional(),
         })
       )
       .optional(),

--- a/src/pages/teams/[team].astro
+++ b/src/pages/teams/[team].astro
@@ -3,6 +3,8 @@ import { getCollection } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import CoachTitle from "../../components/teams/CoachTitle.astro";
 import PlayerCard from "../../components/teams/PlayerCard.astro";
+import ScheduleTable from "../../components/teams/ScheduleTable.astro";
+import ResultsTable from "../../components/teams/ResultsTable.astro";
 import RichText from "../../components/RichText.astro";
 import { headshotImage, teamPhotoImage } from "../../lib/sanity/image";
 import { EXTERNAL_URLS } from "../../config";
@@ -287,115 +289,34 @@ const inactiveTabClass =
         </section>
 
         <!-- Schedule Section -->
-        <section id="schedule-section" class="team-section hidden">
-          <h2 class="section-heading">
-            {team.data.scheduleHeading.toUpperCase()}
-          </h2>
-          {
-            team.data.schedule && team.data.schedule.length > 0 ? (
-              <div class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
-                <table class="w-full text-left text-sm">
-                  <thead>
-                    <tr class="bg-red text-white">
-                      <th class="px-4 py-3 font-semibold tracking-wide uppercase">
-                        Dates
-                      </th>
-                      <th class="px-4 py-3 font-semibold tracking-wide uppercase">
-                        Tournament
-                      </th>
-                      <th class="hidden px-4 py-3 font-semibold tracking-wide uppercase sm:table-cell">
-                        Location
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                    {team.data.schedule.map((event, i) => (
-                      <tr
-                        class={
-                          i % 2 === 0
-                            ? "bg-white dark:bg-gray-900"
-                            : "bg-gray-50 dark:bg-gray-800/50"
-                        }
-                      >
-                        <td class="px-4 py-3 font-mono text-xs whitespace-nowrap text-gray-600 dark:text-gray-400">
-                          {event.dates}
-                        </td>
-                        <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
-                          {event.tournament}
-                          <div class="mt-0.5 text-xs text-gray-500 sm:hidden dark:text-gray-400">
-                            {event.location}
-                          </div>
-                        </td>
-                        <td class="hidden px-4 py-3 text-gray-600 sm:table-cell dark:text-gray-400">
-                          {event.location}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <div class="card">
-                <p class="body-text">Coming soon.</p>
-              </div>
-            )
-          }
+        <!-- Fall first, then spring/summer: the fall season starts the playing
+             year, so it's the one a visitor in September is looking for. -->
+        <section id="schedule-section" class="team-section hidden space-y-12">
+          <div>
+            <ScheduleTable
+              heading={team.data.fallScheduleHeading}
+              rows={team.data.fallSchedule}
+            />
+          </div>
+          <div>
+            <ScheduleTable
+              heading={team.data.scheduleHeading}
+              rows={team.data.schedule}
+            />
+          </div>
         </section>
 
         <!-- Results Section -->
-        <section id="results-section" class="team-section hidden">
-          <h2 class="section-heading">
-            {team.data.resultsHeading.toUpperCase()}
-          </h2>
+        <!-- One table per year, in whatever order the coach arranged them in the
+             Studio — the guidance there is newest first. -->
+        <section id="results-section" class="team-section hidden space-y-12">
           {
-            team.data.results && team.data.results.length > 0 ? (
-              <div class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
-                <table class="w-full text-left text-sm">
-                  <thead>
-                    <tr class="bg-red text-white">
-                      <th class="px-4 py-3 font-semibold tracking-wide uppercase">
-                        Date
-                      </th>
-                      <th class="px-4 py-3 font-semibold tracking-wide uppercase">
-                        Tournament
-                      </th>
-                      <th class="hidden px-4 py-3 font-semibold tracking-wide uppercase sm:table-cell">
-                        Location
-                      </th>
-                      <th class="px-4 py-3 font-semibold tracking-wide uppercase">
-                        Result
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                    {team.data.results.map((entry, i) => (
-                      <tr
-                        class={
-                          i % 2 === 0
-                            ? "bg-white dark:bg-gray-900"
-                            : "bg-gray-50 dark:bg-gray-800/50"
-                        }
-                      >
-                        <td class="px-4 py-3 font-mono text-xs whitespace-nowrap text-gray-600 dark:text-gray-400">
-                          {entry.date}
-                        </td>
-                        <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
-                          {entry.tournament}
-                          <div class="mt-0.5 text-xs text-gray-500 sm:hidden dark:text-gray-400">
-                            {entry.location}
-                          </div>
-                        </td>
-                        <td class="hidden px-4 py-3 text-gray-600 sm:table-cell dark:text-gray-400">
-                          {entry.location}
-                        </td>
-                        <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
-                          {entry.result}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+            team.data.resultTables && team.data.resultTables.length > 0 ? (
+              team.data.resultTables.map(table => (
+                <div>
+                  <ResultsTable heading={table.heading} rows={table.rows} />
+                </div>
+              ))
             ) : (
               <div class="card">
                 <p class="body-text">Coming soon.</p>

--- a/studio/schemaTypes/team.ts
+++ b/studio/schemaTypes/team.ts
@@ -42,6 +42,39 @@ const bioBlock = defineArrayMember({
 });
 
 /**
+ * One tournament on a schedule. Shared by the fall and spring/summer tables so
+ * the two stay identical — a coach filling in one has learned both.
+ */
+const scheduleEvent = defineArrayMember({
+  type: "object",
+  name: "event",
+  fields: [
+    defineField({
+      name: "dates",
+      title: "Dates",
+      type: "string",
+      description: 'Free text, e.g. "5/22 - 5/24".',
+      validation: Rule => Rule.required(),
+    }),
+    defineField({
+      name: "tournament",
+      title: "Tournament",
+      type: "string",
+      validation: Rule => Rule.required(),
+    }),
+    defineField({
+      name: "location",
+      title: "Location",
+      type: "string",
+      validation: Rule => Rule.required(),
+    }),
+  ],
+  preview: {
+    select: { title: "tournament", subtitle: "dates" },
+  },
+});
+
+/**
  * A team: roster, coaching staff, schedule and results.
  *
  * One document per team. Field groups mirror the tabs on the website so the
@@ -262,106 +295,124 @@ export const team = defineType({
     }),
 
     defineField({
-      name: "scheduleHeading",
-      title: "Schedule heading",
+      name: "fallScheduleHeading",
+      title: "Fall schedule heading",
       type: "string",
       group: "schedule",
       description:
-        'Shown above the schedule table, in capitals. Update each season, e.g. "2026 Spring/Summer Schedule".',
-      initialValue: "2026 Spring/Summer Schedule",
+        'Shown above the fall table, in capitals. Update each season, e.g. "2026 Fall Schedule".',
+      initialValue: "2026 Fall Schedule",
+      validation: Rule => Rule.required(),
+    }),
+    defineField({
+      name: "fallSchedule",
+      title: "Fall tournaments",
+      type: "array",
+      group: "schedule",
+      description:
+        'Drag to reorder. Leave empty and the fall table shows "Coming soon".',
+      of: [scheduleEvent],
+    }),
+
+    // Historically the only schedule, which is why the field is plainly
+    // `schedule` while its fall counterpart above is prefixed. Renaming it would
+    // mean moving live coach content to change nothing a coach can see — the
+    // titles below are what they read in the Studio.
+    defineField({
+      name: "scheduleHeading",
+      title: "Spring/summer schedule heading",
+      type: "string",
+      group: "schedule",
+      description:
+        'Shown above the spring/summer table, in capitals. Update each season, e.g. "2027 Spring/Summer Schedule" — or just "2027 Summer Schedule".',
+      initialValue: "2027 Spring/Summer Schedule",
       validation: Rule => Rule.required(),
     }),
     defineField({
       name: "schedule",
-      title: "Tournaments",
+      title: "Spring/summer tournaments",
       type: "array",
       group: "schedule",
       description:
-        'Drag to reorder. Leave empty and the tab shows "Coming soon".',
-      of: [
-        defineArrayMember({
-          type: "object",
-          name: "event",
-          fields: [
-            defineField({
-              name: "dates",
-              title: "Dates",
-              type: "string",
-              description: 'Free text, e.g. "5/22 - 5/24".',
-              validation: Rule => Rule.required(),
-            }),
-            defineField({
-              name: "tournament",
-              title: "Tournament",
-              type: "string",
-              validation: Rule => Rule.required(),
-            }),
-            defineField({
-              name: "location",
-              title: "Location",
-              type: "string",
-              validation: Rule => Rule.required(),
-            }),
-          ],
-          preview: {
-            select: { title: "tournament", subtitle: "dates" },
-          },
-        }),
-      ],
+        'Drag to reorder. Leave empty and the spring/summer table shows "Coming soon".',
+      of: [scheduleEvent],
     }),
 
     defineField({
-      name: "resultsHeading",
-      title: "Results heading",
-      type: "string",
-      group: "results",
-      description:
-        'Shown above the results table, in capitals. Update each season, e.g. "2025 Fall Results".',
-      initialValue: "2025 Fall Results",
-      validation: Rule => Rule.required(),
-    }),
-    defineField({
-      name: "results",
-      title: "Finishes",
+      name: "resultTables",
+      title: "Results by year",
       type: "array",
       group: "results",
       description:
-        'Drag to reorder. Leave empty and the tab shows "Coming soon".',
+        'One table per year, each with its own heading. Add a new one each season rather than overwriting the last — old finishes are worth keeping. Drag to reorder, newest year first. Leave empty and the tab shows "Coming soon".',
       of: [
         defineArrayMember({
           type: "object",
-          name: "result",
+          name: "resultTable",
           fields: [
             defineField({
-              name: "date",
-              title: "Date",
-              type: "string",
-              description: 'Free text, e.g. "Oct 11".',
-              validation: Rule => Rule.required(),
-            }),
-            defineField({
-              name: "tournament",
-              title: "Tournament",
-              type: "string",
-              validation: Rule => Rule.required(),
-            }),
-            defineField({
-              name: "location",
-              title: "Location",
-              type: "string",
-              validation: Rule => Rule.required(),
-            }),
-            defineField({
-              name: "result",
-              title: "Finish",
+              name: "heading",
+              title: "Heading",
               type: "string",
               description:
-                'Free text, e.g. "Champions", "2nd Place", "Semi-Finalist".',
+                'Shown above this table, in capitals, e.g. "2025 Fall Results".',
               validation: Rule => Rule.required(),
+            }),
+            defineField({
+              name: "rows",
+              title: "Finishes",
+              type: "array",
+              description:
+                'Drag to reorder. Leave empty and this table shows "Coming soon", which is handy for a season that has started but has no finishes yet.',
+              of: [
+                defineArrayMember({
+                  type: "object",
+                  name: "result",
+                  fields: [
+                    defineField({
+                      name: "date",
+                      title: "Date",
+                      type: "string",
+                      description: 'Free text, e.g. "Oct 11".',
+                      validation: Rule => Rule.required(),
+                    }),
+                    defineField({
+                      name: "tournament",
+                      title: "Tournament",
+                      type: "string",
+                      validation: Rule => Rule.required(),
+                    }),
+                    defineField({
+                      name: "location",
+                      title: "Location",
+                      type: "string",
+                      validation: Rule => Rule.required(),
+                    }),
+                    defineField({
+                      name: "result",
+                      title: "Finish",
+                      type: "string",
+                      description:
+                        'Free text, e.g. "Champions", "2nd Place", "Semi-Finalist".',
+                      validation: Rule => Rule.required(),
+                    }),
+                  ],
+                  preview: {
+                    select: { title: "tournament", subtitle: "result" },
+                  },
+                }),
+              ],
             }),
           ],
           preview: {
-            select: { title: "tournament", subtitle: "result" },
+            select: { title: "heading", rows: "rows" },
+            prepare: ({ title, rows }) => ({
+              title: title || "Untitled table",
+              subtitle:
+                rows?.length === 1
+                  ? "1 finish"
+                  : `${rows?.length ?? 0} finishes`,
+            }),
           },
         }),
       ],

--- a/studio/scripts/migrate-team-tables.mjs
+++ b/studio/scripts/migrate-team-tables.mjs
@@ -1,0 +1,122 @@
+/**
+ * One-off: bring existing teams onto the new Schedule and Results structure.
+ *
+ * Two changes, both of which need existing documents filled in — `initialValue`
+ * in the schema only applies to documents created after it:
+ *
+ * 1. The Schedule tab gained a fall table alongside the spring/summer one, so
+ *    every team needs a `fallScheduleHeading`. The tournaments themselves stay
+ *    empty until a coach adds them, which renders as "Coming soon".
+ *
+ * 2. Results used to be one fixed table per team — `resultsHeading` plus a flat
+ *    `results` array — so a new season meant deleting last season's finishes.
+ *    They are now a list of tables, one per year, that coaches add to. This
+ *    copies what each team has today into its first table.
+ *
+ * Run from the studio/ folder, BEFORE merging the branch that reads the new
+ * fields. Nothing reads them until then, so this is invisible to the live site,
+ * and merging afterwards finds the data already in place:
+ *
+ *   npx sanity exec scripts/migrate-team-tables.mjs --with-user-token
+ *
+ * Re-running is safe: anything already done is skipped.
+ *
+ * The old results fields are deliberately left behind as a backup. Once the live
+ * site is confirmed good, clear them with:
+ *
+ *   npx sanity exec scripts/migrate-team-tables.mjs --with-user-token -- --cleanup
+ */
+import { getCliClient } from "sanity/cli";
+
+const client = getCliClient();
+const cleanup = process.argv.includes("--cleanup");
+
+/** Matches the schema's initialValue, so new and existing teams start alike. */
+const FALL_HEADING = "2026 Fall Schedule";
+
+/**
+ * Sanity needs a `_key` on every array member. The rows already have one from
+ * their old array; the table wrapping them is new, so it needs its own.
+ */
+function keyed(rows) {
+  return (rows ?? []).map((row, i) => ({
+    ...row,
+    _key: row._key ?? `row-${i}`,
+  }));
+}
+
+// Drafts matter: patching only the published document would leave a coach's
+// in-progress draft without the new fields, and publishing it later would wipe
+// what this script just wrote.
+const teams = await client.fetch(
+  `*[_type == "team"]|order(name asc){
+    _id, name, fallScheduleHeading, resultsHeading, results, resultTables
+  }`
+);
+
+if (teams.length === 0) {
+  throw new Error("No team documents found — is the dataset right?");
+}
+
+for (const team of teams) {
+  const isDraft = team._id.startsWith("drafts.");
+  const label = `${team.name ?? team._id}${isDraft ? " (draft)" : ""}`;
+
+  // Loose `== null` throughout: a GROQ projection returns null for an unset
+  // field rather than omitting it, so `=== undefined` would never match and
+  // every team would look like it had already been done.
+  if (cleanup) {
+    if (team.resultsHeading == null && team.results == null) {
+      console.log(`${label}: already clean`);
+      continue;
+    }
+    await client.patch(team._id).unset(["resultsHeading", "results"]).commit();
+    console.log(`${label}: removed legacy resultsHeading/results`);
+    continue;
+  }
+
+  const changes = {};
+  const notes = [];
+
+  if (team.fallScheduleHeading == null) {
+    changes.fallScheduleHeading = FALL_HEADING;
+    notes.push(`fall heading "${FALL_HEADING}"`);
+  }
+
+  // A team with no finishes recorded gets no table at all — the tab shows
+  // "Coming soon", exactly as it does today.
+  if (team.resultTables == null && team.results?.length > 0) {
+    changes.resultTables = [
+      {
+        _key: "table-0",
+        _type: "resultTable",
+        heading: team.resultsHeading ?? "Results",
+        rows: keyed(team.results),
+      },
+    ];
+    notes.push(
+      `results table "${changes.resultTables[0].heading}" with ${changes.resultTables[0].rows.length} row(s)`
+    );
+  }
+
+  if (notes.length === 0) {
+    console.log(`${label}: nothing to do`);
+    continue;
+  }
+
+  await client.patch(team._id).set(changes).commit();
+  console.log(`${label}: ${notes.join(", ")}`);
+}
+
+const check = await client.fetch(
+  `*[_type == "team"]|order(name asc){
+    name,
+    fallScheduleHeading,
+    scheduleHeading,
+    "tables": count(resultTables),
+    "rows": count(resultTables[].rows[]),
+    "legacyRows": count(results)
+  }`
+);
+console.log(`\nResulting team data${cleanup ? " (after cleanup)" : ""}:`);
+console.table(check);


### PR DESCRIPTION
## What changed

**Schedule** now has two tables instead of one — fall first, then spring/summer — each with its own coach-editable heading and tournament list, and its own "Coming soon" when empty.

**Results** is now a list of tables, one per year, that coaches add to themselves. Previously a new season meant deleting last season's finishes to make room. Tables render in whatever order they're arranged in the Studio; the help text says newest first.

Both tables look exactly as they did before.

## Notes

- The existing `schedule` field becomes the spring/summer table — its content already was the spring/summer schedule — so no live coach content moved. The fall counterpart is `fallSchedule`. Field titles in the Studio spell out which is which.
- The three near-identical inline tables on the team page are now `ScheduleTable.astro` and `ResultsTable.astro`, since the page renders two of one and N of the other.
- Row shapes are unchanged, so no per-row data conversion was needed.

## Migration — already run

`studio/scripts/migrate-team-tables.mjs` has been run against production, before this merges, because it writes fields nothing reads yet:

| Team | Fall heading | Results table |
| --- | --- | --- |
| 11U Brown | backfilled | "2025 Fall Results", 5 rows |
| 13U Allen | backfilled | "2025 Fall Results", 2 rows |
| 14U Jones | backfilled | "2025 Fall Results", 3 rows |

`initialValue` only applies to documents created after it, so every existing team needed `fallScheduleHeading` filled in or the build would fail Zod validation. Drafts were patched alongside published documents so publishing an in-progress edit doesn't undo it. The legacy `resultsHeading`/`results` fields are left in place as a backup; `-- --cleanup` removes them once the live site is confirmed.

## Known content issue (deliberately not fixed here)

11U Brown's coach had nowhere to put a fall tournament, so they renamed their heading to "2026 Fall Schedule" and put "Battle For Glory" (9/5-9/6) at the top of an otherwise May–July list. After this merges, Brown's page shows an empty fall table above a spring/summer table headed "2026 Fall Schedule". Their coach can fix it in the Studio in about a minute — which is the whole point of the change.

## Verified

- `format:check`, `lint`, `type-check`, `build`; `tsc --noEmit` and `sanity build` in `studio/`
- Built output for all three teams: fall table shows "Coming soon", spring/summer table carries the existing tournaments, results tables carry 5 / 2 / 3 rows as migrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)